### PR TITLE
Add placeholder to indicate loading state of quickorder form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+
+- Added spinner to indicate loading state of quickorders
+
 ## [0.1.11] - 2022-02-09
 
 ### Fixed

--- a/react/SoldToValidationWrapper.tsx
+++ b/react/SoldToValidationWrapper.tsx
@@ -8,7 +8,12 @@ import OrderSoldToAccount from './queries/orderSoldToAccount.graphql'
 import './sbdsefprod.sold-to-validation.css'
 
 const SoldToValidationWrapper = () => {
-  const CSS_HANDLES = ['soldToAcctErrorMessage', 'errorMessegeContainer']
+  const CSS_HANDLES = [
+    'soldToAcctErrorMessage',
+    'errorMessegeContainer',
+    'quickOrderLoading',
+    'quickOrderSpinnerContainer',
+  ]
 
   const handles = useCssHandles(CSS_HANDLES)
 
@@ -19,7 +24,13 @@ const SoldToValidationWrapper = () => {
   } = useQuery(OrderSoldToAccount, { ssr: false })
 
   if (soldToLoading) {
-    return <Spinner />
+    return (
+      <div className={handles.quickOrderSpinnerContainer}>
+        <div className={handles.quickOrderLoading}>
+          <Spinner />
+        </div>
+      </div>
+    )
   }
 
   if (soldToError) {

--- a/react/SoldToValidationWrapper.tsx
+++ b/react/SoldToValidationWrapper.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { useQuery } from 'react-apollo'
 import { ExtensionPoint } from 'vtex.render-runtime'
 import { useCssHandles } from 'vtex.css-handles'
+import { Spinner } from 'vtex.styleguide'
 
 import OrderSoldToAccount from './queries/orderSoldToAccount.graphql'
 import './sbdsefprod.sold-to-validation.css'
@@ -18,11 +19,11 @@ const SoldToValidationWrapper = () => {
   } = useQuery(OrderSoldToAccount, { ssr: false })
 
   if (soldToLoading) {
-    console.info('soldToLoading', soldToLoading)
+    return <Spinner />
   }
 
   if (soldToError) {
-    console.info('soldToError', soldToError)
+    console.info('ERROR LOADING...', soldToError)
   }
 
   if (!soldToAcctData?.getOrderSoldToAccount) {

--- a/react/sbdsefprod.sold-to-validation.css
+++ b/react/sbdsefprod.sold-to-validation.css
@@ -11,3 +11,15 @@
     justify-content: center;
     font-size: 32px;
 }
+
+.quickOrderSpinnerContainer {
+    display: flex;
+    justify-content: center;
+    min-height: 200px;
+}
+
+.quickOrderLoading {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}


### PR DESCRIPTION
#### What does this PR do? 

- Add spinner to indiacte loading state of quickorders
- Add CSS styles to spinner

#### How to test it?

- Visit the following site and login to account

[workspace](https://navosprod--sbdsefprod.myvtex.com/quickorder?__bindingAddress=catalog2.sef.ao.sbd-prod.com/en-US/catalog-global)

- Select a sold to account and select quickorders
- Spinner should flsah before the quick order form loads