### PR TITLE
Add Punchout2Go quote validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added Punchout2Go quote validation
+
 ### Fixed
 
 - Fixed linting configuration

--- a/manifest.json
+++ b/manifest.json
@@ -154,7 +154,9 @@
     },
     "free": true,
     "type": "free",
-    "availableCountries": ["*"]
+    "availableCountries": [
+      "*"
+    ]
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/AutocompleteBlock.tsx
+++ b/react/AutocompleteBlock.tsx
@@ -31,6 +31,7 @@ import QuickOrderAutocomplete from './components/QuickOrderAutocomplete'
 import productQuery from './queries/product.gql'
 import ORDER_SOLD_TO_ACCOUNT from './queries/orderSoldToAccount.graphql'
 import './global.css'
+import { isPunchoutQuoteSession } from './utils/punchout'
 
 const messages = defineMessages({
   success: {
@@ -358,6 +359,10 @@ const AutocompleteBlock: FunctionComponent<any & WrappedComponentProps> = ({
   ] as const
 
   const handles = useCssHandles(CSS_HANDLES)
+
+  if (!orderForm?.orderForm || isPunchoutQuoteSession(orderForm.orderForm)) {
+    return null
+  }
 
   return (
     <div className={`${handles.textContainerMain} flex flex-column`}>

--- a/react/CategoryBlock.tsx
+++ b/react/CategoryBlock.tsx
@@ -26,6 +26,7 @@ import { graphql, useApolloClient, compose, useMutation } from 'react-apollo'
 
 import getCategories from './queries/categoriesQuery.gql'
 import SearchByCategory from './queries/productsByCategory.gql'
+import { isPunchoutQuoteSession } from './utils/punchout'
 
 const messages = defineMessages({
   success: {
@@ -87,7 +88,7 @@ const CategoryBlock: FunctionComponent<WrappedComponentProps & any> = ({
   const { settings = {}, showInstallPrompt = undefined } = usePWA() || {}
   const { promptOnCustomEvent } = settings
 
-  const { setOrderForm }: OrderFormContext = OrderForm.useOrderForm()
+  const { orderForm, setOrderForm }: OrderFormContext = OrderForm.useOrderForm()
 
   const resolveToastMessage = (success: boolean, isNewItem: boolean) => {
     if (!success) return intl.formatMessage(messages.error)
@@ -488,6 +489,10 @@ const CategoryBlock: FunctionComponent<WrappedComponentProps & any> = ({
         )}
       </Collapsible>
     )
+  }
+
+  if (!orderForm || isPunchoutQuoteSession(orderForm)) {
+    return null
   }
 
   return (

--- a/react/PunchoutReview.tsx
+++ b/react/PunchoutReview.tsx
@@ -1,0 +1,365 @@
+import React, { useContext, useState } from 'react'
+import { useOrderForm } from 'vtex.order-manager/OrderForm'
+import { Button, Spinner, Table, ToastContext } from 'vtex.styleguide'
+import type { MessageDescriptor } from 'react-intl'
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl'
+import { useCssHandles } from 'vtex.css-handles'
+import { useMutation } from 'react-apollo'
+import type { OrderForm as OrderFormType } from 'vtex.checkout-graphql/graphql/__types_entrypoint'
+import { addToCart as ADD_TO_CART } from 'vtex.checkout-resources/Mutations'
+import { usePixel } from 'vtex.pixel-manager/PixelContext'
+import { usePWA } from 'vtex.store-resources/PWAContext'
+
+import ItemListContext from './ItemListContext'
+import { GetText } from './utils'
+import ReviewBlock from './components/ReviewBlock'
+
+const CSS_HANDLES = [
+  'reviewBlock',
+  'buttonsBlock',
+  'addToCartDisabled',
+  'addToCartBtn',
+  'buttonValidate',
+] as const
+
+interface ItemType {
+  id: string
+  quantity: number
+}
+
+const messages = defineMessages({
+  success: {
+    id: 'store/toaster.cart.success',
+    defaultMessage: '',
+    label: '',
+  },
+  duplicate: {
+    id: 'store/toaster.cart.duplicated',
+    defaultMessage: '',
+    label: '',
+  },
+  error: { id: 'store/toaster.cart.error', defaultMessage: '', label: '' },
+  seeCart: {
+    id: 'store/toaster.cart.seeCart',
+    defaultMessage: '',
+    label: '',
+  },
+})
+
+const PunchoutReview = () => {
+  const { orderForm, setOrderForm } = useOrderForm()
+  const { push } = usePixel()
+  const { settings = {}, showInstallPrompt = undefined } = usePWA() || {}
+  const { promptOnCustomEvent } = settings
+  const handles = useCssHandles(CSS_HANDLES)
+  const intl = useIntl()
+  const [state, setState] = useState<any>({
+    reviewItems: [],
+    reviewState: false,
+    showAddToCart: false,
+  })
+
+  const { reviewItems, reviewState } = state
+  const [refidLoading, setRefIdLoading] = useState<any>()
+  const { useItemListState, useItemListDispatch } = ItemListContext
+  const dispatch = useItemListDispatch()
+  const { showAddToCart } = useItemListState()
+  const { showToast } = useContext(ToastContext)
+  const [addToCart, { error: mutationError, loading: mutationLoading }] =
+    useMutation<{ addToCart: OrderFormType }, { items: [] }>(ADD_TO_CART)
+
+  const translateMessage = (message: MessageDescriptor) => {
+    return intl.formatMessage(message)
+  }
+
+  const resolveToastMessage = (success: boolean, isNewItem: boolean) => {
+    if (!success) return translateMessage(messages.error)
+    if (!isNewItem) return translateMessage(messages.duplicate)
+
+    return translateMessage(messages.success)
+  }
+
+  const toastMessage = ({
+    success,
+    isNewItem,
+  }: {
+    success: boolean
+    isNewItem: boolean
+  }) => {
+    const message = resolveToastMessage(success, isNewItem)
+
+    showToast({ message })
+  }
+
+  const quoteItems = JSON.parse(
+    (orderForm.customData?.customApps ?? []).find(
+      (app) => app.id === 'punchout-to-go'
+    )?.fields.quoteItems ?? '[]'
+  )
+
+  const callAddToCart = async (items: any) => {
+    const currentItemsInCart = orderForm.items
+    const mutationResult = await addToCart({
+      variables: {
+        items: items.map((item: ItemType) => {
+          const [existsInCurrentOrder] = currentItemsInCart.filter(
+            (el: any) => el.id === item.id.toString()
+          )
+
+          if (existsInCurrentOrder) {
+            item.quantity += parseInt(existsInCurrentOrder.quantity, 10)
+          }
+
+          return {
+            ...item,
+          }
+        }),
+      },
+    })
+
+    if (mutationError) {
+      console.error(mutationError)
+      toastMessage({ success: false, isNewItem: false })
+
+      return
+    }
+
+    // Update OrderForm from the context
+    mutationResult.data && setOrderForm(mutationResult.data.addToCart)
+
+    const adjustSkuItemForPixelEvent = (item: any) => {
+      return {
+        skuId: item.id,
+        quantity: item.quantity,
+      }
+    }
+
+    // Send event to pixel-manager
+    const pixelEventItems = items.map(adjustSkuItemForPixelEvent)
+
+    push({
+      event: 'addToCart',
+      items: pixelEventItems,
+    })
+
+    if (
+      mutationResult.data?.addToCart?.messages?.generalMessages &&
+      mutationResult.data.addToCart.messages.generalMessages.length
+    ) {
+      mutationResult.data.addToCart.messages.generalMessages.map((msg: any) => {
+        return showToast({
+          message: msg.text,
+          action: undefined,
+          duration: 30000,
+        })
+      })
+    } else {
+      toastMessage({ success: true, isNewItem: true })
+    }
+
+    if (promptOnCustomEvent === 'addToCart' && showInstallPrompt) {
+      showInstallPrompt()
+    }
+
+    return showInstallPrompt
+  }
+
+  const addToCartCopyNPaste = () => {
+    const items: any = reviewItems
+      .filter((item: any) => item.error === null && item.vtexSku !== null)
+      .map(({ vtexSku, quantity, seller, unit }: any) => {
+        return {
+          id: parseInt(vtexSku, 10),
+          quantity: parseFloat(quantity) / unit,
+          seller,
+        }
+      })
+
+    const merge = (internalItems: any) => {
+      return internalItems.reduce((acc, val) => {
+        const { id, quantity }: ItemType = val
+        const ind = acc.findIndex((el: any) => el.id === id)
+
+        if (ind !== -1) {
+          acc[ind].quantity += quantity
+        } else {
+          acc.push(val)
+        }
+
+        return acc
+      }, [])
+    }
+
+    const mergedItems = merge(items)
+
+    callAddToCart(mergedItems)
+  }
+
+  const onReviewItems = (items: any) => {
+    if (items) {
+      const show =
+        items.filter((item: any) => {
+          return !item.vtexSku
+        }).length === 0
+
+      setState({
+        ...state,
+        reviewItems: items,
+        reviewState: true,
+        showAddToCart: show,
+        textAreaValue: GetText(items),
+      })
+
+      dispatch({
+        type: 'UPDATE_ALL_STATUSES',
+        args: {
+          itemStatuses: items.map((item: any) => ({
+            index: item.index,
+            availability: item.availability,
+            error: item.error,
+            sku: item.sku,
+            availableQuantity: !Number.isNaN(item.availableQuantity)
+              ? parseInt(item.availableQuantity, 10)
+              : 0,
+          })),
+        },
+      })
+    }
+
+    return true
+  }
+
+  const onRefidLoading = (data: boolean) => {
+    setRefIdLoading(data)
+  }
+
+  const backList = () => {
+    setState({
+      ...state,
+      reviewState: false,
+    })
+  }
+
+  const parseText = () => {
+    const items: any = quoteItems || []
+    const error = !!items.filter((item: any) => {
+      return item.error !== null
+    }).length
+
+    setState({
+      ...state,
+      reviewItems: items,
+      reviewState: true,
+      hasError: error,
+      toValidate: true,
+      textAreaValue: GetText(items),
+    })
+
+    dispatch({
+      type: 'ADD_STATUSES',
+      args: {
+        itemStatuses: items.map((item: any, index: number) => ({
+          index,
+          error: item.error,
+          sku: item.sku,
+        })),
+      },
+    })
+  }
+
+  if (quoteItems.length === 0) {
+    return null
+  }
+
+  if (!reviewState) {
+    return (
+      <div className="w-100 mb5">
+        <div className="bg-base t-body c-on-base ph3 br3 b--muted-4">
+          <div className="mb5">
+            <Table
+              fullWidth
+              schema={{
+                properties: {
+                  sku: {
+                    title: 'Reference code',
+                    minWidth: 350,
+                  },
+                  quantity: {
+                    title: 'Quantity',
+                    // default is 200px
+                    minWidth: 100,
+                  },
+                },
+              }}
+              items={quoteItems}
+              density="high"
+              onRowClick={({ rowData }) => {
+                alert(
+                  `you just clicked ${rowData.name}, number is ${rowData.number} and email ${rowData.email}`
+                )
+              }}
+            />
+          </div>
+          <div className={`mt2 flex justify-end ${handles.buttonValidate}`}>
+            <Button
+              variation="secondary"
+              size="regular"
+              onClick={() => {
+                parseText()
+              }}
+            >
+              <FormattedMessage id="store/quickorder.validate" />
+            </Button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className={`w-100 ph4 ${handles.reviewBlock}`}>
+      <ReviewBlock
+        reviewedItems={quoteItems.map((quoteItem: any, index) => {
+          return {
+            ...quoteItem,
+            index,
+            line: index,
+            error: null,
+            content: `${quoteItem.sku},${quoteItem.quantity}`,
+          }
+        })}
+        onReviewItems={onReviewItems}
+        onRefidLoading={onRefidLoading}
+      />
+      <div
+        className={`mb4 mt4 flex justify-between ${handles.buttonsBlock} ${
+          !showAddToCart ? handles.addToCartDisabled : handles.addToCartBtn
+        }`}
+      >
+        <Button
+          variation="tertiary"
+          size="small"
+          onClick={() => {
+            backList()
+          }}
+        >
+          <FormattedMessage id="store/quickorder.back" />
+        </Button>
+        {refidLoading && <Spinner />}
+        <Button
+          variation="primary"
+          size="small"
+          isLoading={mutationLoading}
+          onClick={() => {
+            addToCartCopyNPaste()
+          }}
+          disabled={!showAddToCart}
+        >
+          <FormattedMessage id="store/quickorder.addToCart" />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default PunchoutReview

--- a/react/PunchoutReviewWrapper.tsx
+++ b/react/PunchoutReviewWrapper.tsx
@@ -4,24 +4,11 @@ import { useOrderForm } from 'vtex.order-manager/OrderForm'
 
 import ItemListContext from './ItemListContext'
 import GET_ACCOUNT_INFO from './queries/orderSoldToAccount.graphql'
-import UploadBlock from './UploadBlock'
 import { isPunchoutQuoteSession } from './utils/punchout'
+import PunchoutReview from './PunchoutReview'
 
-interface UploadBlockInterface {
-  text?: string
-  description?: string
-  componentOnly?: boolean
-  downloadText?: string
-}
-
-const UploadBlockWrapper = ({
-  text,
-  description,
-  componentOnly,
-  downloadText,
-}: UploadBlockInterface) => {
+const PunchoutReviewWrapper = () => {
   const { ItemListProvider } = ItemListContext
-  const { orderForm } = useOrderForm()
 
   const { data: accountData, loading: accountDataLoading } = useQuery(
     GET_ACCOUNT_INFO,
@@ -31,7 +18,9 @@ const UploadBlockWrapper = ({
     }
   )
 
-  if (isPunchoutQuoteSession(orderForm)) {
+  const { orderForm } = useOrderForm()
+
+  if (!isPunchoutQuoteSession(orderForm)) {
     return null
   }
 
@@ -40,9 +29,9 @@ const UploadBlockWrapper = ({
       accountData={accountData}
       accountDataLoading={accountDataLoading}
     >
-      <UploadBlock {...{ text, description, componentOnly, downloadText }} />
+      <PunchoutReview />
     </ItemListProvider>
   )
 }
 
-export default UploadBlockWrapper
+export default PunchoutReviewWrapper

--- a/react/TextAreaBlockWrapper.tsx
+++ b/react/TextAreaBlockWrapper.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import { useQuery } from 'react-apollo'
+import { useOrderForm } from 'vtex.order-manager/OrderForm'
 
 import ItemListContext from './ItemListContext'
 import GET_ACCOUNT_INFO from './queries/orderSoldToAccount.graphql'
 import TextAreaBlock from './TextAreaBlock'
+import { isPunchoutQuoteSession } from './utils/punchout'
 
 interface TextAreaBlockInterface {
   value: string
@@ -29,6 +31,12 @@ const TextAreaBlockWrapper = ({
       ssr: false,
     }
   )
+
+  const { orderForm } = useOrderForm()
+
+  if (isPunchoutQuoteSession(orderForm)) {
+    return null
+  }
 
   return (
     <ItemListProvider

--- a/react/utils/punchout.ts
+++ b/react/utils/punchout.ts
@@ -1,0 +1,8 @@
+import type { OrderForm } from 'vtex.checkout-graphql'
+
+export const isPunchoutQuoteSession = (orderForm: OrderForm) =>
+  JSON.parse(
+    (orderForm.customData?.customApps ?? []).find(
+      (app) => app.id === 'punchout-to-go'
+    )?.fields.quoteItems ?? '[]'
+  ).length > 0

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -22,5 +22,8 @@
   "quickorder-textarea": {
     "component": "TextAreaBlockWrapper"
   },
+  "quickorder-punchout": {
+    "component": "PunchoutReviewWrapper"
+  },
   "store.quickorder": {}
 }


### PR DESCRIPTION
#### What does this PR do? \*

This PR adds support for Punchout2Go quote validation (phase 02)

#### How to test it? \*

Go to the [test workspace](https://p2gquote--sbdsefuat.myvtex.com/quickorder?__bindingAddress=catalog.sef.ao.sbd-nonprod.com/en-GB/catalog-eu), and fill the custom field `quoteItems` of the app `punchout-to-go` in the order form, with the following value (use the checkout API).

`JSON.stringify([{sku: '02931-01013', quantity: 50000}, {sku: '02931-00811', quantity: 10}])`

Refresh the quick order page.